### PR TITLE
FIX: Added Router.php to override Bramus getRequestMethod()

### DIFF
--- a/src/App/Core/Router.php
+++ b/src/App/Core/Router.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use Bramus\Router\Router as BramusRouter;
+
+class Router extends BramusRouter
+{
+	public function getRequestMethod(): string
+    {
+        return $_POST['_method'] ?? parent::getRequestMethod();
+    }
+}

--- a/src/App/Http/Controllers/UserController.php
+++ b/src/App/Http/Controllers/UserController.php
@@ -36,7 +36,7 @@ class UserController
 
 		Feedback::for('user_destroy_success')->toast([
 			'text' => static::USER_DESTROY_SUCCESS,
-			'style' => 'danger',
+			'style' => 'success',
 			'icon' => 'fa-regular fa-check-circle',
 		]);
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -2,7 +2,7 @@
 
 use App\Core\App;
 use App\Core\Redirect;
-use Bramus\Router\Router;
+use App\Core\Router;
 use App\Core\Authenticate as Auth;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\ProfileController;


### PR DESCRIPTION
By adding Router.php that extends the Bramus Router class we can override the `getRequestMethod()` method so that we donät have to manually edit the file every time we install Beets. Closes #15 